### PR TITLE
Add a check for jq

### DIFF
--- a/generate_docker-compose.sh
+++ b/generate_docker-compose.sh
@@ -4,6 +4,13 @@
 ## WeatherFlow Collector - generate_docker-compose.sh
 ##
 
+# Check for jq and exit if not installed
+if ! command -v jq &> /dev/null
+then
+    echo "The 'jq' utility is not installed. Please install 'jq' to continue."
+    exit 1
+fi
+
 import_days=$WEATHERFLOW_COLLECTOR_IMPORT_DAYS
 influxdb_password=$WEATHERFLOW_COLLECTOR_INFLUXDB_PASSWORD
 influxdb_url=$WEATHERFLOW_COLLECTOR_INFLUXDB_URL


### PR DESCRIPTION
Hi,

I noticed the `docker-compose.sh` script uses `jq`; I didn't have it installed when I ran it so it displayed a bunch of errors.

If the script is going to use `jq` we should check for it before continuing on with the script.